### PR TITLE
Fix dnsmasq-stack.yml example

### DIFF
--- a/dnsmasq-stack.yml
+++ b/dnsmasq-stack.yml
@@ -1,5 +1,5 @@
 dnsmasq:
   cap_add:
-    - CAP_NET_ADMIN
+    - NET_ADMIN
   image: 'imj0sh/dockercloud-dnsmasq'
   restart: always


### PR DESCRIPTION
Produced the following error when deployed in Docker Cloud and the service would fail to start:
ERROR: dnsmasq: linux spec capabilities: Unknown capability to add: "CAP_CAP_NET_ADMIN"
Trimming out the leading CAP_ in the cap_add: section solves this problem.
